### PR TITLE
Removed floorsheet methods/types from master

### DIFF
--- a/nepse/market/core.py
+++ b/nepse/market/core.py
@@ -1,9 +1,8 @@
-import asyncio
 from typing import List
 
 import humps
 
-from nepse.market.types import FloorSheet, MarketCap
+from nepse.market.types import MarketCap
 from nepse.utils import _ClientWrapperHTTPX
 
 BASE_URL = "https://newweb.nepalstock.com/api/nots"
@@ -62,36 +61,3 @@ class MarketClient:
         )
         data = humps.decamelize(resp)
         return [MarketCap(**model) for model in data]
-
-    async def get_floorsheets(self) -> List[FloorSheet]:
-        """Returns the floorsheet data for the current date
-
-        Returns:
-            List[FloorSheet]: List of floorsheet data in form of `FloorSheet`
-        """
-        contents = []
-        tasks = []
-
-        pages = (
-            await self._client_wrapper._get_json(f"{BASE_URL}/nepse-data/floorsheet")
-            .get("floorsheets")
-            .get("totalPages")
-        )
-
-        async def _get_floorsheet_page(page_no: int):
-            response = (
-                await self._client_wrapper._get_json(
-                    f"{BASE_URL}nots/nepse-data/floorsheet?page={page_no}&size=2000&sort=contractId,desc"
-                )
-                .get("floorsheets")
-                .get("content")
-            )
-            data = humps.decamelize(response)
-            return FloorSheet(**data)
-
-        for page_no in range(pages):
-            tasks.append(_get_floorsheet_page(page_no))
-
-        await asyncio.gather(*tasks)
-
-        return contents

--- a/nepse/market/types.py
+++ b/nepse/market/types.py
@@ -13,8 +13,3 @@ class MarketCap:
     def __post_init__(self) -> None:
         year, month, day = self.business_date.split("-")
         self.business_date = datetime.date(int(year), int(month), int(day))
-
-
-@dataclass
-class FloorSheet:
-    pass


### PR DESCRIPTION
Solved #19 

Removed floorsheet related methods/types from the master branch, as floorsheet related types/methods are still under development and aren't well tested, and it has many issues as well such as #20 