### PR TITLE
Changed id to 281 in POST request for the API

### DIFF
--- a/nepse/utils.py
+++ b/nepse/utils.py
@@ -22,9 +22,9 @@ class _ClientWrapperHTTPX:
             raise APIError()
 
     # Created this cause NEPSE API requires POST request
-    # with `{"id": 678}` in body.
+    # with `{"id": 281}` in body.
     async def _post_json_defualt_body(self, url: str) -> object:
-        body = {"id": 678}
+        body = {"id": 281}
         return (await self._client.post(url, json=body)).json()
 
     async def _post_json(self, url: str, body: dict) -> object:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nepse-api"
-version = "1.1.2"
+version = "1.1.3"
 description = "This is a API wrapper for NEPSE API."
 authors = ["Samrid Pandit <samrid.pandit@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Fixed #27  where the API's post request's payload's `id` was changing randomly and finally stabilized at `281`. And bumped to version 1.1.3 for the patch.