### PR TITLE
Adds `total_trade_value` in the `SecurityResponse`

### DIFF
--- a/nepse/security/types.py
+++ b/nepse/security/types.py
@@ -140,6 +140,7 @@ class SecurityResponse:
     last_updated_date_time: datetime.datetime
     last_traded_volume: Any
     previous_close: int
+    total_trade_value: int
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nepse-api"
-version = "1.1.8"
+version = "1.1.9"
 description = "This is a API wrapper for NEPSE API."
 authors = ["Samrid Pandit <samrid.pandit@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Fixes the breaking API change and bumps to `v1.1.9` for the patch.